### PR TITLE
Changing the master/slave language

### DIFF
--- a/api-guide/source/conf.py
+++ b/api-guide/source/conf.py
@@ -46,8 +46,8 @@ todo_include_todos = True
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 # General information about the project.
 project = u'Compute API Guide'
 bug_tag = u'api-guide'

--- a/api-ref/source/conf.py
+++ b/api-ref/source/conf.py
@@ -36,8 +36,8 @@ extensions = [
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 copyright = u'2010-present, OpenStack Foundation'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,8 +66,8 @@ seqdiag_antialias = True
 
 todo_include_todos = True
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 copyright = u'2010-present, OpenStack Foundation'

--- a/nova/api/openstack/compute/server_groups.py
+++ b/nova/api/openstack/compute/server_groups.py
@@ -55,7 +55,7 @@ def _get_not_deleted(context, uuids):
     cell_mappings = {}
     found_inst_uuids = []
 
-    # Get a master list of cell mappings, and a list of instance
+    # Get a main list of cell mappings, and a list of instance
     # uuids organized by cell
     for im in mappings:
         if not im.cell_mapping:

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3778,10 +3778,10 @@ class API(base.Base):
             with nova_context.target_cell(context, hm.cell_mapping) as cctxt:
                 node = objects.ComputeNode.\
                     get_first_node_by_host_for_old_compat(
-                        cctxt, host_name, use_slave=True)
+                        cctxt, host_name, use_subordinate=True)
         else:
             node = objects.ComputeNode.get_first_node_by_host_for_old_compat(
-                context, host_name, use_slave=True)
+                context, host_name, use_subordinate=True)
 
         return node
 

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -675,7 +675,7 @@ class ComputeManager(manager.Manager):
                 return objects.InstanceList()
             filters['uuid'] = driver_uuids
             local_instances = objects.InstanceList.get_by_filters(
-                context, filters, use_slave=True)
+                context, filters, use_subordinate=True)
             return local_instances
         except NotImplementedError:
             pass
@@ -687,7 +687,7 @@ class ComputeManager(manager.Manager):
         # Without this all instance data would be fetched from db.
         filters['host'] = self.host
         instances = objects.InstanceList.get_by_filters(context, filters,
-                                                        use_slave=True)
+                                                        use_subordinate=True)
         name_map = {instance.name: instance for instance in instances}
         local_instances = []
         for driver_instance in driver_instances:
@@ -1707,7 +1707,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
 
         building_insts = objects.InstanceList.get_by_filters(context,
-                           filters, expected_attrs=[], use_slave=True)
+                           filters, expected_attrs=[], use_subordinate=True)
 
         for instance in building_insts:
             if timeutils.is_older_than(instance.created_at, timeout):
@@ -2024,7 +2024,7 @@ class ComputeManager(manager.Manager):
         context = context.elevated()
         instances = objects.InstanceList.get_by_host(context, self.host,
                                                      expected_attrs=[],
-                                                     use_slave=True)
+                                                     use_subordinate=True)
         uuids = [instance.uuid for instance in instances]
         self.query_client.sync_instance_info(context, self.host, uuids)
 
@@ -8877,7 +8877,7 @@ class ComputeManager(manager.Manager):
             # The list of instances to heal is empty so rebuild it
             LOG.debug('Rebuilding the list of instances to heal')
             db_instances = objects.InstanceList.get_by_host(
-                context, self.host, expected_attrs=[], use_slave=True)
+                context, self.host, expected_attrs=[], use_subordinate=True)
             for inst in db_instances:
                 # We don't want to refresh the cache for instances
                 # which are building or deleting so don't put them
@@ -8908,7 +8908,7 @@ class ComputeManager(manager.Manager):
                             context, instance_uuids.pop(0),
                             expected_attrs=['system_metadata', 'info_cache',
                                             'flavor'],
-                            use_slave=True)
+                            use_subordinate=True)
                 except exception.InstanceNotFound:
                     # Instance is gone.  Try to grab another.
                     continue
@@ -8969,7 +8969,7 @@ class ComputeManager(manager.Manager):
                         task_states.REBOOT_PENDING],
                        'host': self.host}
             rebooting = objects.InstanceList.get_by_filters(
-                context, filters, expected_attrs=[], use_slave=True)
+                context, filters, expected_attrs=[], use_subordinate=True)
 
             to_poll = []
             for instance in rebooting:
@@ -8986,7 +8986,7 @@ class ComputeManager(manager.Manager):
                        'host': self.host}
             rescued_instances = objects.InstanceList.get_by_filters(
                 context, filters, expected_attrs=["system_metadata"],
-                use_slave=True)
+                use_subordinate=True)
 
             to_unrescue = []
             for instance in rescued_instances:
@@ -9004,7 +9004,7 @@ class ComputeManager(manager.Manager):
 
         migrations = objects.MigrationList.get_unconfirmed_by_dest_compute(
                 context, CONF.resize_confirm_window, self.host,
-                use_slave=True)
+                use_subordinate=True)
 
         migrations_info = dict(migration_count=len(migrations),
                 confirm_window=CONF.resize_confirm_window)
@@ -9032,7 +9032,7 @@ class ComputeManager(manager.Manager):
             try:
                 instance = objects.Instance.get_by_uuid(context,
                             instance_uuid, expected_attrs=expected_attrs,
-                            use_slave=True)
+                            use_subordinate=True)
             except exception.InstanceNotFound:
                 reason = (_("Instance %s not found") %
                           instance_uuid)
@@ -9092,7 +9092,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
         shelved_instances = objects.InstanceList.get_by_filters(
             context, filters=filters, expected_attrs=['system_metadata'],
-            use_slave=True)
+            use_subordinate=True)
 
         to_gc = []
         for instance in shelved_instances:
@@ -9125,7 +9125,7 @@ class ComputeManager(manager.Manager):
             context, begin, end, host=self.host,
             expected_attrs=['system_metadata', 'info_cache', 'metadata',
                             'flavor'],
-            use_slave=True)
+            use_subordinate=True)
         num_instances = len(instances)
         errors = 0
         successes = 0
@@ -9179,7 +9179,7 @@ class ComputeManager(manager.Manager):
 
             instances = objects.InstanceList.get_by_host(context,
                                                               self.host,
-                                                              use_slave=True)
+                                                              use_subordinate=True)
             try:
                 bw_counters = self.driver.get_all_bw_counters(instances)
             except NotImplementedError:
@@ -9204,7 +9204,7 @@ class ComputeManager(manager.Manager):
                 last_ctr_out = None
                 usage = objects.BandwidthUsage.get_by_instance_uuid_and_mac(
                     context, bw_ctr['uuid'], bw_ctr['mac_address'],
-                    start_period=start_time, use_slave=True)
+                    start_period=start_time, use_subordinate=True)
                 if usage:
                     bw_in = usage.bw_in
                     bw_out = usage.bw_out
@@ -9214,7 +9214,7 @@ class ComputeManager(manager.Manager):
                     usage = (objects.BandwidthUsage.
                              get_by_instance_uuid_and_mac(
                         context, bw_ctr['uuid'], bw_ctr['mac_address'],
-                        start_period=prev_time, use_slave=True))
+                        start_period=prev_time, use_subordinate=True))
                     if usage:
                         last_ctr_in = usage.last_ctr_in
                         last_ctr_out = usage.last_ctr_out
@@ -9243,14 +9243,14 @@ class ComputeManager(manager.Manager):
                                               start_period=start_time,
                                               last_refreshed=refreshed)
 
-    def _get_host_volume_bdms(self, context, use_slave=False):
+    def _get_host_volume_bdms(self, context, use_subordinate=False):
         """Return all block device mappings on a compute host."""
         compute_host_bdms = []
         instances = objects.InstanceList.get_by_host(context, self.host,
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         for instance in instances:
             bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
-                    context, instance.uuid, use_slave=use_slave)
+                    context, instance.uuid, use_subordinate=use_subordinate)
             instance_bdms = [bdm for bdm in bdms if bdm.is_volume]
             compute_host_bdms.append(dict(instance=instance,
                                           instance_bdms=instance_bdms))
@@ -9283,7 +9283,7 @@ class ComputeManager(manager.Manager):
             return
 
         compute_host_bdms = self._get_host_volume_bdms(context,
-                                                       use_slave=True)
+                                                       use_subordinate=True)
         if not compute_host_bdms:
             return
 
@@ -9309,7 +9309,7 @@ class ComputeManager(manager.Manager):
         """
         db_instances = objects.InstanceList.get_by_host(context, self.host,
                                                         expected_attrs=[],
-                                                        use_slave=True)
+                                                        use_subordinate=True)
 
         try:
             num_vm_instances = self.driver.get_num_instances()
@@ -9375,7 +9375,7 @@ class ComputeManager(manager.Manager):
             self._sync_instance_power_state(context,
                                             db_instance,
                                             vm_power_state,
-                                            use_slave=True)
+                                            use_subordinate=True)
         except exception.InstanceNotFound:
             # NOTE(hanlind): If the instance gets deleted during sync,
             # silently ignore.
@@ -9420,7 +9420,7 @@ class ComputeManager(manager.Manager):
                               instance=db_instance)
 
     def _sync_instance_power_state(self, context, db_instance, vm_power_state,
-                                   use_slave=False):
+                                   use_subordinate=False):
         """Align instance power state between the database and hypervisor.
 
         If the instance is not found on the hypervisor, but is in the database,
@@ -9429,7 +9429,7 @@ class ComputeManager(manager.Manager):
 
         # We re-query the DB to get the latest instance info to minimize
         # (not eliminate) race condition.
-        db_instance.refresh(use_slave=use_slave)
+        db_instance.refresh(use_subordinate=use_subordinate)
         db_power_state = db_instance.power_state
         vm_state = db_instance.vm_state
 
@@ -9569,7 +9569,7 @@ class ComputeManager(manager.Manager):
         instances = objects.InstanceList.get_by_filters(
             context, filters,
             expected_attrs=objects.instance.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True)
+            use_subordinate=True)
         for instance in instances:
             if self._deleted_old_enough(instance, interval):
                 bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
@@ -9642,7 +9642,7 @@ class ComputeManager(manager.Manager):
         """
 
         compute_nodes_in_db = self._get_compute_nodes_in_db(context,
-                                                            use_slave=True,
+                                                            use_subordinate=True,
                                                             startup=startup)
         try:
             nodenames = set(self.driver.get_available_nodes())
@@ -9674,11 +9674,11 @@ class ComputeManager(manager.Manager):
             self._update_available_resource_for_node(context, nodename,
                                                      startup=startup)
 
-    def _get_compute_nodes_in_db(self, context, use_slave=False,
+    def _get_compute_nodes_in_db(self, context, use_subordinate=False,
                                  startup=False):
         try:
             return objects.ComputeNodeList.get_all_by_host(context, self.host,
-                                                           use_slave=use_slave)
+                                                           use_subordinate=use_subordinate)
         except exception.NotFound:
             if startup:
                 LOG.warning(
@@ -9762,7 +9762,7 @@ class ComputeManager(manager.Manager):
                              "DELETED but still present on host.",
                              instance.name, instance=instance)
                     bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
-                        context, instance.uuid, use_slave=True)
+                        context, instance.uuid, use_subordinate=True)
                     self.instance_events.clear_events_for_instance(instance)
                     try:
                         self._shutdown_instance(context, instance, bdms,
@@ -9854,11 +9854,11 @@ class ComputeManager(manager.Manager):
                 self._set_instance_obj_error_state(context, instance)
 
     @wrap_exception()
-    def add_aggregate_host(self, context, aggregate, host, slave_info):
+    def add_aggregate_host(self, context, aggregate, host, subordinate_info):
         """Notify hypervisor of change (for hypervisor pools)."""
         try:
             self.driver.add_to_aggregate(context, aggregate, host,
-                                         slave_info=slave_info)
+                                         subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'add_aggregate_host')
@@ -9870,11 +9870,11 @@ class ComputeManager(manager.Manager):
                                     aggregate, host)
 
     @wrap_exception()
-    def remove_aggregate_host(self, context, host, slave_info, aggregate):
+    def remove_aggregate_host(self, context, host, subordinate_info, aggregate):
         """Removes a host from a physical hypervisor pool."""
         try:
             self.driver.remove_from_aggregate(context, aggregate, host,
-                                              slave_info=slave_info)
+                                              subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'remove_aggregate_host')
@@ -10179,7 +10179,7 @@ class ComputeManager(manager.Manager):
                    'soft_deleted': True,
                    'host': nodes}
         filtered_instances = objects.InstanceList.get_by_filters(context,
-                                 filters, expected_attrs=[], use_slave=True)
+                                 filters, expected_attrs=[], use_subordinate=True)
 
         self.driver.manage_image_cache(context, filtered_instances)
 
@@ -10232,7 +10232,7 @@ class ComputeManager(manager.Manager):
         attrs = ['system_metadata']
         with utils.temporary_mutation(context, read_deleted='yes'):
             instances = objects.InstanceList.get_by_filters(
-                context, filters, expected_attrs=attrs, use_slave=True)
+                context, filters, expected_attrs=attrs, use_subordinate=True)
         LOG.debug('There are %d instances to clean', len(instances))
 
         for instance in instances:
@@ -10276,7 +10276,7 @@ class ComputeManager(manager.Manager):
         attrs = ['info_cache', 'security_groups', 'system_metadata']
         with utils.temporary_mutation(context, read_deleted='yes'):
             instances = objects.InstanceList.get_by_filters(
-                context, inst_filters, expected_attrs=attrs, use_slave=True)
+                context, inst_filters, expected_attrs=attrs, use_subordinate=True)
 
         for instance in instances:
             if instance.host != CONF.host:

--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -156,7 +156,7 @@ class ComputeAPI(object):
 
         * 2.0 - Remove 1.x backwards compat
         * 2.1 - Adds orig_sys_metadata to rebuild_instance()
-        * 2.2 - Adds slave_info parameter to add_aggregate_host() and
+        * 2.2 - Adds subordinate_info parameter to add_aggregate_host() and
                 remove_aggregate_host()
         * 2.3 - Adds volume_id to reserve_block_device_name()
         * 2.4 - Add bdms to terminate_instance
@@ -507,7 +507,7 @@ class ComputeAPI(object):
                               call_monitor_timeout=cmt)
 
     def add_aggregate_host(self, ctxt, host, aggregate, host_param,
-                           slave_info=None):
+                           subordinate_info=None):
         '''Add aggregate host.
 
         :param ctxt: request context
@@ -521,7 +521,7 @@ class ComputeAPI(object):
                 server=host, version=version)
         cctxt.cast(ctxt, 'add_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def add_fixed_ip_to_instance(self, ctxt, instance, network_id):
         version = '5.0'
@@ -1078,7 +1078,7 @@ class ComputeAPI(object):
                    **msg_args)
 
     def remove_aggregate_host(self, ctxt, host, aggregate, host_param,
-                              slave_info=None):
+                              subordinate_info=None):
         '''Remove aggregate host.
 
         :param ctxt: request context
@@ -1092,7 +1092,7 @@ class ComputeAPI(object):
                 server=host, version=version)
         cctxt.cast(ctxt, 'remove_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def remove_fixed_ip_from_instance(self, ctxt, instance, address):
         version = '5.0'

--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -996,7 +996,7 @@ class ComputeTaskManager(base.Base):
                 context, instance.host, instance.node)
             dest_node = (
                 objects.ComputeNode.get_first_node_by_host_for_old_compat(
-                    context, host, use_slave=True))
+                    context, host, use_subordinate=True))
         except exception.ComputeHostNotFound as ex:
             with excutils.save_and_reraise_exception():
                 self._set_vm_state_and_notify(

--- a/nova/conductor/rpcapi.py
+++ b/nova/conductor/rpcapi.py
@@ -126,7 +126,7 @@ class ConductorAPI(object):
     * 1.62 - Added object_backport()
     * 1.63 - Changed the format of values['stats'] from a dict to a JSON string
              in compute_node_update()
-    * 1.64 - Added use_slave to instance_get_all_filters()
+    * 1.64 - Added use_subordinate to instance_get_all_filters()
            - Remove instance_type_get()
            - Remove aggregate_get()
            - Remove aggregate_get_by_host()

--- a/nova/conf/database.py
+++ b/nova/conf/database.py
@@ -52,7 +52,7 @@ api_db_opts = [
     cfg.BoolOpt('sqlite_synchronous',
         default=True,
         help=''),
-    cfg.StrOpt('slave_connection',
+    cfg.StrOpt('subordinate_connection',
         secret=True,
         help=''),
     cfg.StrOpt('mysql_sql_mode',

--- a/nova/conf/network.py
+++ b/nova/conf/network.py
@@ -1012,19 +1012,19 @@ nova-network is deprecated, as are any related configuration options.
 nova-network is deprecated, as are any related configuration options.
 """,
         help="Bind user's password for LDAP server"),
-    cfg.StrOpt('ldap_dns_soa_hostmaster',
-        default='hostmaster@example.org',
+    cfg.StrOpt('ldap_dns_soa_hostmain',
+        default='hostmain@example.org',
         deprecated_for_removal=True,
         deprecated_since='16.0.0',
         deprecated_reason="""
 nova-network is deprecated, as are any related configuration options.
 """,
         help="""
-Hostmaster for LDAP DNS driver Statement of Authority
+Hostmain for LDAP DNS driver Statement of Authority
 
 Possible values:
 
-* Any valid string representing LDAP DNS hostmaster.
+* Any valid string representing LDAP DNS hostmain.
 """),
     cfg.MultiStrOpt('ldap_dns_servers',
         default=['dns.example.org'],
@@ -1062,7 +1062,7 @@ nova-network is deprecated, as are any related configuration options.
         help="""
 Refresh interval (in seconds) for LDAP DNS driver Start of Authority
 
-Time interval, a secondary/slave DNS server waits before requesting for
+Time interval, a secondary/subordinate DNS server waits before requesting for
 primary DNS server's current SOA record. If the records are different,
 secondary DNS server will request a zone transfer from primary.
 
@@ -1078,7 +1078,7 @@ nova-network is deprecated, as are any related configuration options.
         help="""
 Retry interval (in seconds) for LDAP DNS driver Start of Authority
 
-Time interval, a secondary/slave DNS server should wait, if an
+Time interval, a secondary/subordinate DNS server should wait, if an
 attempt to transfer zone failed during the previous refresh interval.
 """),
     cfg.IntOpt('ldap_dns_soa_expiry',
@@ -1091,7 +1091,7 @@ nova-network is deprecated, as are any related configuration options.
         help="""
 Expiry interval (in seconds) for LDAP DNS driver Start of Authority
 
-Time interval, a secondary/slave DNS server holds the information
+Time interval, a secondary/subordinate DNS server holds the information
 before it is no longer considered authoritative.
 """),
     cfg.IntOpt('ldap_dns_soa_minimum',

--- a/nova/conf/xvp.py
+++ b/nova/conf/xvp.py
@@ -40,7 +40,7 @@ xvp_opts = [
     cfg.StrOpt('console_xvp_pid',
                default='/var/run/xvp.pid',
                deprecated_group='DEFAULT',
-               help='XVP master process pid file'),
+               help='XVP main process pid file'),
     cfg.StrOpt('console_xvp_log',
                default='/var/log/xvp.log',
                deprecated_group='DEFAULT',

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -85,8 +85,8 @@ def create_context_manager(connection):
 def select_db_reader_mode(f):
     """Decorator to select synchronous or asynchronous reader mode.
 
-    The kwarg argument 'use_slave' defines reader mode. Asynchronous reader
-    will be used if 'use_slave' is True and synchronous reader otherwise.
+    The kwarg argument 'use_subordinate' defines reader mode. Asynchronous reader
+    will be used if 'use_subordinate' is True and synchronous reader otherwise.
     """
     return IMPL.select_db_reader_mode(f)
 

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -136,14 +136,14 @@ def get_context_manager(context):
     return _context_manager_from_context(context) or main_context_manager
 
 
-def get_engine(use_slave=False, context=None):
+def get_engine(use_subordinate=False, context=None):
     """Get a database engine object.
 
-    :param use_slave: Whether to use the slave connection
+    :param use_subordinate: Whether to use the subordinate connection
     :param context: The request context that can contain a context manager
     """
     ctxt_mgr = get_context_manager(context)
-    if use_slave:
+    if use_subordinate:
         return ctxt_mgr.reader.get_engine()
     return ctxt_mgr.writer.get_engine()
 
@@ -184,9 +184,9 @@ def require_context(f):
 def select_db_reader_mode(f):
     """Decorator to select synchronous or asynchronous reader mode.
 
-    The kwarg argument 'use_slave' defines reader mode. Asynchronous reader
-    will be used if 'use_slave' is True and synchronous reader otherwise.
-    If 'use_slave' is not specified default value 'False' will be used.
+    The kwarg argument 'use_subordinate' defines reader mode. Asynchronous reader
+    will be used if 'use_subordinate' is True and synchronous reader otherwise.
+    If 'use_subordinate' is not specified default value 'False' will be used.
 
     Wrapped function must have a context in the arguments.
     """
@@ -197,9 +197,9 @@ def select_db_reader_mode(f):
         keyed_args = inspect.getcallargs(wrapped_func, *args, **kwargs)
 
         context = keyed_args['context']
-        use_slave = keyed_args.get('use_slave', False)
+        use_subordinate = keyed_args.get('use_subordinate', False)
 
-        if use_slave:
+        if use_subordinate:
             reader_mode = get_context_manager(context).async_
         else:
             reader_mode = get_context_manager(context).reader
@@ -5427,7 +5427,7 @@ def archive_deleted_rows(context=None, max_rows=None, before=None):
     table_to_rows_archived = {}
     deleted_instance_uuids = []
     total_rows_archived = 0
-    meta = MetaData(get_engine(use_slave=True, context=context))
+    meta = MetaData(get_engine(use_subordinate=True, context=context))
     meta.reflect()
     # Reverse sort the tables so we get the leaf nodes first for processing.
     for table in reversed(meta.sorted_tables):

--- a/nova/network/ldapdns.py
+++ b/nova/network/ldapdns.py
@@ -116,7 +116,7 @@ class DomainEntry(DNSEntry):
         date = time.strftime('%Y%m%d%H%M%S')
         soa = '%s %s %s %d %d %d %d' % (
                  CONF.ldap_dns_servers[0],
-                 CONF.ldap_dns_soa_hostmaster,
+                 CONF.ldap_dns_soa_hostmain,
                  date,
                  CONF.ldap_dns_soa_refresh,
                  CONF.ldap_dns_soa_retry,

--- a/nova/network/linux_net.py
+++ b/nova/network/linux_net.py
@@ -1357,7 +1357,7 @@ class LinuxBridgeInterfaceDriver(LinuxNetInterfaceDriver):
             out, err = nova.privsep.linux_net.bridge_add_interface(
                            bridge, interface)
             if (err and err != "device %s is already a member of a bridge; "
-                     "can't enslave it to bridge %s.\n" % (interface, bridge)):
+                     "can't ensubordinate it to bridge %s.\n" % (interface, bridge)):
                 msg = _('Failed to add interface: %s') % err
                 raise exception.NovaException(msg)
 

--- a/nova/objects/bandwidth_usage.py
+++ b/nova/objects/bandwidth_usage.py
@@ -18,7 +18,7 @@ from nova.objects import fields
 @base.NovaObjectRegistry.register
 class BandwidthUsage(base.NovaPersistentObject, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_instance_uuid_and_mac
+    # Version 1.1: Add use_subordinate to get_by_instance_uuid_and_mac
     # Version 1.2: Add update_cells to create
     VERSION = '1.2'
 
@@ -46,17 +46,17 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject):
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+    def _db_bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
         return db.bw_usage_get(context, uuid=uuid, start_period=start_period,
                                mac=mac)
 
     @base.serialize_args
     @base.remotable_classmethod
     def get_by_instance_uuid_and_mac(cls, context, instance_uuid, mac,
-                                     start_period=None, use_slave=False):
+                                     start_period=None, use_subordinate=False):
         db_bw_usage = cls._db_bw_usage_get(context, uuid=instance_uuid,
                                       start_period=start_period, mac=mac,
-                                      use_slave=use_slave)
+                                      use_subordinate=use_subordinate)
         if db_bw_usage:
             return cls._from_db_object(context, cls(), db_bw_usage)
 
@@ -76,7 +76,7 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject):
 @base.NovaObjectRegistry.register
 class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_uuids
+    # Version 1.1: Add use_subordinate to get_by_uuids
     # Version 1.2: BandwidthUsage <= version 1.2
     VERSION = '1.2'
     fields = {
@@ -86,14 +86,14 @@ class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_bw_usage_get_by_uuids(context, uuids, start_period,
-                                  use_slave=False):
+                                  use_subordinate=False):
         return db.bw_usage_get_by_uuids(context, uuids=uuids,
                                         start_period=start_period)
 
     @base.serialize_args
     @base.remotable_classmethod
-    def get_by_uuids(cls, context, uuids, start_period=None, use_slave=False):
+    def get_by_uuids(cls, context, uuids, start_period=None, use_subordinate=False):
         db_bw_usages = cls._db_bw_usage_get_by_uuids(context, uuids=uuids,
                                                 start_period=start_period,
-                                                use_slave=use_slave)
+                                                use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(), BandwidthUsage, db_bw_usages)

--- a/nova/objects/block_device.py
+++ b/nova/objects/block_device.py
@@ -130,8 +130,8 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject,
         # non-nullable in a future release.
 
         # NOTE(mdbooth): We wrap this method in a retry loop because it can
-        # fail (safely) on multi-master galera if concurrent updates happen on
-        # different masters. It will never fail on single-master. We can only
+        # fail (safely) on multi-main galera if concurrent updates happen on
+        # different mains. It will never fail on single-main. We can only
         # ever need one retry.
 
         uuid = uuidutils.generate_uuid()
@@ -335,7 +335,7 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject,
 class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     # Version 1.1: BlockDeviceMapping <= version 1.1
-    # Version 1.2: Added use_slave to get_by_instance_uuid
+    # Version 1.2: Added use_subordinate to get_by_instance_uuid
     # Version 1.3: BlockDeviceMapping <= version 1.2
     # Version 1.4: BlockDeviceMapping <= version 1.3
     # Version 1.5: BlockDeviceMapping <= version 1.4
@@ -373,28 +373,28 @@ class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_block_device_mapping_get_all_by_instance_uuids(
-            context, instance_uuids, use_slave=False):
+            context, instance_uuids, use_subordinate=False):
         return db.block_device_mapping_get_all_by_instance_uuids(
                 context, instance_uuids)
 
     @base.remotable_classmethod
-    def get_by_instance_uuids(cls, context, instance_uuids, use_slave=False):
+    def get_by_instance_uuids(cls, context, instance_uuids, use_subordinate=False):
         db_bdms = cls._db_block_device_mapping_get_all_by_instance_uuids(
-            context, instance_uuids, use_slave=use_slave)
+            context, instance_uuids, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 
     @staticmethod
     @db.select_db_reader_mode
     def _db_block_device_mapping_get_all_by_instance(
-            context, instance_uuid, use_slave=False):
+            context, instance_uuid, use_subordinate=False):
         return db.block_device_mapping_get_all_by_instance(
             context, instance_uuid)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_bdms = cls._db_block_device_mapping_get_all_by_instance(
-            context, instance_uuid, use_slave=use_slave)
+            context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -285,8 +285,8 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
     # TODO(pkholkin): Remove this method in the next major version bump
     @base.remotable_classmethod
     def get_first_node_by_host_for_old_compat(cls, context, host,
-                                              use_slave=False):
-        computes = ComputeNodeList.get_all_by_host(context, host, use_slave)
+                                              use_subordinate=False):
+        computes = ComputeNodeList.get_all_by_host(context, host, use_subordinate)
         # FIXME(sbauza): Ironic deployments can return multiple
         # nodes per host, we should return all the nodes and modify the callers
         # instead.
@@ -389,7 +389,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # Version 1.2 Add get_by_service()
     # Version 1.3 ComputeNode version 1.4
     # Version 1.4 ComputeNode version 1.5
-    # Version 1.5 Add use_slave to get_by_service
+    # Version 1.5 Add use_subordinate to get_by_service
     # Version 1.6 ComputeNode version 1.6
     # Version 1.7 ComputeNode version 1.7
     # Version 1.8 ComputeNode version 1.8 + add get_all_by_host()
@@ -438,7 +438,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # NOTE(hanlind): This is deprecated and should be removed on the next
     # major version bump
     @base.remotable_classmethod
-    def _get_by_service(cls, context, service_id, use_slave=False):
+    def _get_by_service(cls, context, service_id, use_subordinate=False):
         try:
             db_computes = db.compute_nodes_get_by_service_id(
                 context, service_id)
@@ -451,13 +451,13 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_compute_node_get_all_by_host(context, host, use_slave=False):
+    def _db_compute_node_get_all_by_host(context, host, use_subordinate=False):
         return db.compute_node_get_all_by_host(context, host)
 
     @base.remotable_classmethod
-    def get_all_by_host(cls, context, host, use_slave=False):
+    def get_all_by_host(cls, context, host, use_subordinate=False):
         db_computes = cls._db_compute_node_get_all_by_host(context, host,
-                                                      use_slave=use_slave)
+                                                      use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.ComputeNode,
                                   db_computes)
 

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -507,17 +507,17 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
     @staticmethod
     @db.select_db_reader_mode
     def _db_instance_get_by_uuid(context, uuid, columns_to_join,
-                                 use_slave=False):
+                                 use_subordinate=False):
         return db.instance_get_by_uuid(context, uuid,
                                        columns_to_join=columns_to_join)
 
     @base.remotable_classmethod
-    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_slave=False):
+    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_subordinate=False):
         if expected_attrs is None:
             expected_attrs = ['info_cache', 'security_groups']
         columns_to_join = _expected_cols(expected_attrs)
         db_inst = cls._db_instance_get_by_uuid(context, uuid, columns_to_join,
-                                               use_slave=use_slave)
+                                               use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_inst,
                                    expected_attrs)
 
@@ -836,12 +836,12 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         self.obj_reset_changes()
 
     @base.remotable
-    def refresh(self, use_slave=False):
+    def refresh(self, use_subordinate=False):
         extra = [field for field in INSTANCE_OPTIONAL_ATTRS
                        if self.obj_attr_is_set(field)]
         current = self.__class__.get_by_uuid(self._context, uuid=self.uuid,
                                              expected_attrs=extra,
-                                             use_slave=use_slave)
+                                             use_subordinate=use_subordinate)
         # NOTE(danms): We orphan the instance copy so we do not unexpectedly
         # trigger a lazy-load (which would mean we failed to calculate the
         # expected_attrs properly)
@@ -1266,7 +1266,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @db.select_db_reader_mode
     def _get_by_filters_impl(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False,
+                       marker=None, expected_attrs=None, use_subordinate=False,
                        sort_keys=None, sort_dirs=None):
         if sort_keys or sort_dirs:
             db_inst_list = db.instance_get_all_by_filters_sort(
@@ -1282,12 +1282,12 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def get_by_filters(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False,
+                       marker=None, expected_attrs=None, use_subordinate=False,
                        sort_keys=None, sort_dirs=None):
         db_inst_list = cls._get_by_filters_impl(
             context, filters, sort_key=sort_key, sort_dir=sort_dir,
             limit=limit, marker=marker, expected_attrs=expected_attrs,
-            use_slave=use_slave, sort_keys=sort_keys, sort_dirs=sort_dirs)
+            use_subordinate=use_subordinate, sort_keys=sort_keys, sort_dirs=sort_dirs)
         # NOTE(melwitt): _make_instance_list could result in joined objects'
         # (from expected_attrs) _from_db_object methods being called during
         # Instance._from_db_object, each of which might choose to perform
@@ -1299,15 +1299,15 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_instance_get_all_by_host(context, host, columns_to_join,
-                                     use_slave=False):
+                                     use_subordinate=False):
         return db.instance_get_all_by_host(context, host,
                                            columns_to_join=columns_to_join)
 
     @base.remotable_classmethod
-    def get_by_host(cls, context, host, expected_attrs=None, use_slave=False):
+    def get_by_host(cls, context, host, expected_attrs=None, use_subordinate=False):
         db_inst_list = cls._db_instance_get_all_by_host(
             context, host, columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
@@ -1365,7 +1365,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @db.select_db_reader_mode
     def _db_instance_get_active_by_window_joined(
             context, begin, end, project_id, host, columns_to_join,
-            use_slave=False, limit=None, marker=None):
+            use_subordinate=False, limit=None, marker=None):
         return db.instance_get_active_by_window_joined(
             context, begin, end, project_id, host,
             columns_to_join=columns_to_join, limit=limit, marker=marker)
@@ -1373,7 +1373,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def _get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
-                                    expected_attrs=None, use_slave=False,
+                                    expected_attrs=None, use_subordinate=False,
                                     limit=None, marker=None):
         # NOTE(mriedem): We need to convert the begin/end timestamp strings
         # to timezone-aware datetime objects for the DB API call.
@@ -1382,14 +1382,14 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         db_inst_list = cls._db_instance_get_active_by_window_joined(
             context, begin, end, project_id, host,
             columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave, limit=limit, marker=marker)
+            use_subordinate=use_subordinate, limit=limit, marker=marker)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
     @classmethod
     def get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
-                                    expected_attrs=None, use_slave=False,
+                                    expected_attrs=None, use_subordinate=False,
                                     limit=None, marker=None):
         """Get instances and joins active during a certain time window.
 
@@ -1400,7 +1400,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         :param:host: used to filter instances on a given compute host
         :param:expected_attrs: list of related fields that can be joined
         in the database layer when querying for instances
-        :param use_slave if True, ship this query off to a DB slave
+        :param use_subordinate if True, ship this query off to a DB subordinate
         :param limit: maximum number of instances to return per page
         :param marker: last instance uuid from the previous page
         :returns: InstanceList
@@ -1413,7 +1413,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         return cls._get_active_by_window_joined(context, begin, end,
                                                 project_id, host,
                                                 expected_attrs,
-                                                use_slave=use_slave,
+                                                use_subordinate=use_subordinate,
                                                 limit=limit, marker=marker)
 
     @base.remotable_classmethod

--- a/nova/objects/migration.py
+++ b/nova/objects/migration.py
@@ -210,7 +210,7 @@ class Migration(base.NovaPersistentObject, base.NovaObject,
 class MigrationList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     #              Migration <= 1.1
-    # Version 1.1: Added use_slave to get_unconfirmed_by_dest_compute
+    # Version 1.1: Added use_subordinate to get_unconfirmed_by_dest_compute
     # Version 1.2: Migration version 1.2
     # Version 1.3: Added a new function to get in progress migrations
     #              for an instance.
@@ -225,15 +225,15 @@ class MigrationList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=False):
+            context, confirm_window, dest_compute, use_subordinate=False):
         return db.migration_get_unconfirmed_by_dest_compute(
             context, confirm_window, dest_compute)
 
     @base.remotable_classmethod
     def get_unconfirmed_by_dest_compute(cls, context, confirm_window,
-                                        dest_compute, use_slave=False):
+                                        dest_compute, use_subordinate=False):
         db_migrations = cls._db_migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=use_slave)
+            context, confirm_window, dest_compute, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.Migration,
                                   db_migrations)
 

--- a/nova/objects/service.py
+++ b/nova/objects/service.py
@@ -187,7 +187,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
     # Version 1.1: Added compute_node nested object
     # Version 1.2: String attributes updated to support unicode
     # Version 1.3: ComputeNode version 1.5
-    # Version 1.4: Added use_slave to get_by_compute_host
+    # Version 1.4: Added use_subordinate to get_by_compute_host
     # Version 1.5: ComputeNode version 1.6
     # Version 1.6: ComputeNode version 1.7
     # Version 1.7: ComputeNode version 1.8
@@ -356,13 +356,13 @@ class Service(base.NovaPersistentObject, base.NovaObject,
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_service_get_by_compute_host(context, host, use_slave=False):
+    def _db_service_get_by_compute_host(context, host, use_subordinate=False):
         return db.service_get_by_compute_host(context, host)
 
     @base.remotable_classmethod
-    def get_by_compute_host(cls, context, host, use_slave=False):
+    def get_by_compute_host(cls, context, host, use_subordinate=False):
         db_service = cls._db_service_get_by_compute_host(context, host,
-                                                         use_slave=use_slave)
+                                                         use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_service)
 
     # NOTE(ndipanov): This is deprecated and should be removed on the next
@@ -457,11 +457,11 @@ class Service(base.NovaPersistentObject, base.NovaObject,
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_service_get_minimum_version(context, binaries, use_slave=False):
+    def _db_service_get_minimum_version(context, binaries, use_subordinate=False):
         return db.service_get_minimum_version(context, binaries)
 
     @base.remotable_classmethod
-    def get_minimum_version_multi(cls, context, binaries, use_slave=False):
+    def get_minimum_version_multi(cls, context, binaries, use_subordinate=False):
         if not all(binary.startswith('nova-') for binary in binaries):
             LOG.warning('get_minimum_version called with likely-incorrect '
                         'binaries `%s\'', ','.join(binaries))
@@ -472,7 +472,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
               any(binary not in cls._MIN_VERSION_CACHE
                   for binary in binaries)):
             min_versions = cls._db_service_get_minimum_version(
-                context, binaries, use_slave=use_slave)
+                context, binaries, use_subordinate=use_subordinate)
             if min_versions:
                 min_versions = {binary: version or 0
                                 for binary, version in
@@ -493,9 +493,9 @@ class Service(base.NovaPersistentObject, base.NovaObject,
         return version
 
     @base.remotable_classmethod
-    def get_minimum_version(cls, context, binary, use_slave=False):
+    def get_minimum_version(cls, context, binary, use_subordinate=False):
         return cls.get_minimum_version_multi(context, [binary],
-                                             use_slave=use_slave)
+                                             use_subordinate=use_subordinate)
 
 
 def get_minimum_version_all_cells(context, binaries, require_all=False):

--- a/nova/objects/virtual_interface.py
+++ b/nova/objects/virtual_interface.py
@@ -139,13 +139,13 @@ class VirtualInterfaceList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_virtual_interface_get_by_instance(context, instance_uuid,
-                                              use_slave=False):
+                                              use_subordinate=False):
         return db.virtual_interface_get_by_instance(context, instance_uuid)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_vifs = cls._db_virtual_interface_get_by_instance(
-            context, instance_uuid, use_slave=use_slave)
+            context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context),
                                   objects.VirtualInterface, db_vifs)
 

--- a/nova/pci/manager.py
+++ b/nova/pci/manager.py
@@ -40,7 +40,7 @@ class PciDevTracker(object):
     devices to/from instances, and to update the available pci passthrough
     device information from the hypervisor periodically.
 
-    The `pci_devs` attribute of this class is the in-memory "master copy" of
+    The `pci_devs` attribute of this class is the in-memory "main copy" of
     all devices on each compute host, and all data changes that happen when
     claiming/allocating/freeing devices HAVE TO be made against instances
     contained in `pci_devs` list, because they are periodically flushed to the

--- a/nova/tests/unit/api/openstack/compute/test_server_actions.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_actions.py
@@ -971,7 +971,7 @@ class ServerActionsControllerTestV21(test.TestCase):
                     delete_on_termination=False)]
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -1083,7 +1083,7 @@ class ServerActionsControllerTestV21(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/nova/tests/unit/api/openstack/compute/test_server_metadata.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_metadata.py
@@ -78,7 +78,7 @@ def stub_max_server_metadata():
 
 
 def return_server_nonexistent(context, server_id,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 

--- a/nova/tests/unit/api/openstack/compute/test_serversV21.py
+++ b/nova/tests/unit/api/openstack/compute/test_serversV21.py
@@ -135,7 +135,7 @@ def fake_start_stop_invalid_state(self, context, instance):
 
 
 def fake_instance_get_by_uuid_not_found(context, uuid,
-                                        columns_to_join, use_slave=False):
+                                        columns_to_join, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=uuid)
 
 

--- a/nova/tests/unit/api/openstack/compute/test_simple_tenant_usage.py
+++ b/nova/tests/unit/api/openstack/compute/test_simple_tenant_usage.py
@@ -115,7 +115,7 @@ def _fake_instance_deleted_flavorless(context, start, end, instance_id,
 @classmethod
 def fake_get_active_deleted_flavorless(cls, context, begin, end=None,
                                        project_id=None, host=None,
-                                       expected_attrs=None, use_slave=False,
+                                       expected_attrs=None, use_subordinate=False,
                                        limit=None, marker=None):
     # First get some normal instances to have actual usage
     instances = [
@@ -135,7 +135,7 @@ def fake_get_active_deleted_flavorless(cls, context, begin, end=None,
 @classmethod
 def fake_get_active_by_window_joined(cls, context, begin, end=None,
                                      project_id=None, host=None,
-                                     expected_attrs=None, use_slave=False,
+                                     expected_attrs=None, use_subordinate=False,
                                      limit=None, marker=None):
     return objects.InstanceList(objects=[
         _fake_instance(START, STOP, x,
@@ -246,12 +246,12 @@ class SimpleTenantUsageTestV21(test.TestCase):
 
         def fake_get_active_by_window_joined(context, begin, end=None,
                                     project_id=None, host=None,
-                                    expected_attrs=None, use_slave=False,
+                                    expected_attrs=None, use_subordinate=False,
                                     limit=None, marker=None):
             self.assertEqual(['flavor'], expected_attrs)
             return orig_get_active_by_window_joined(context, begin, end,
                                                     project_id, host,
-                                                    expected_attrs, use_slave)
+                                                    expected_attrs, use_subordinate)
 
         with mock.patch.object(objects.InstanceList,
                                'get_active_by_window_joined',

--- a/nova/tests/unit/api/openstack/fakes.py
+++ b/nova/tests/unit/api/openstack/fakes.py
@@ -348,7 +348,7 @@ def get_fake_uuid(token=0):
 
 
 def fake_instance_get(**kwargs):
-    def _return_server(context, uuid, columns_to_join=None, use_slave=False):
+    def _return_server(context, uuid, columns_to_join=None, use_subordinate=False):
         if 'project_id' not in kwargs:
             kwargs['project_id'] = 'fake'
         return stub_instance(1, **kwargs)
@@ -379,8 +379,8 @@ def fake_instance_get_all_by_filters(num_servers=5, **kwargs):
         if 'columns_to_join' in kwargs:
             kwargs.pop('columns_to_join')
 
-        if 'use_slave' in kwargs:
-            kwargs.pop('use_slave')
+        if 'use_subordinate' in kwargs:
+            kwargs.pop('use_subordinate')
 
         if 'sort_keys' in kwargs:
             kwargs.pop('sort_keys')
@@ -686,7 +686,7 @@ def stub_snapshot_get_all(self, context):
 
 
 def stub_bdm_get_all_by_instance_uuids(context, instance_uuids,
-                                       use_slave=False):
+                                       use_subordinate=False):
     i = 1
     result = []
     for instance_uuid in instance_uuids:

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -780,7 +780,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get_counter.assert_called_once_with([])
         mock_last.assert_called_once_with()
         mock_get_host.assert_called_once_with(ctxt, 'fake-mini',
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch.object(objects.InstanceList, 'get_by_host')
     @mock.patch.object(objects.BlockDeviceMappingList,
@@ -799,10 +799,10 @@ class ComputeVolumeTestCase(BaseTestCase):
         got_host_bdms = self.compute._get_host_volume_bdms('fake-context')
         mock_get_by_host.assert_called_once_with('fake-context',
                                                  self.compute.host,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         mock_get_by_inst.assert_called_once_with('fake-context',
                                                  uuids.volume_instance,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         self.assertEqual(expected_host_bdms, got_host_bdms)
 
     @mock.patch.object(utils, 'last_completed_audit_period')
@@ -828,7 +828,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(ctxt)
 
-        mock_get_bdms.assert_called_once_with(ctxt, use_slave=True)
+        mock_get_bdms.assert_called_once_with(ctxt, use_subordinate=True)
 
     @mock.patch.object(compute_utils, 'notify_about_volume_usage')
     @mock.patch.object(compute_manager.ComputeManager, '_get_host_volume_bdms')
@@ -848,7 +848,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(self.context)
 
-        mock_get_bdms.assert_called_once_with(self.context, use_slave=True)
+        mock_get_bdms.assert_called_once_with(self.context, use_subordinate=True)
         mock_notify.assert_called_once_with(
             self.context, test.MatchType(objects.VolumeUsage),
             self.compute.host)
@@ -967,7 +967,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get.assert_called_once_with(self.context, uuids.volume_id,
                                          instance.uuid)
         mock_stats.assert_called_once_with(instance, 'vdb')
-        mock_get_bdms.assert_called_once_with(self.context, use_slave=True)
+        mock_get_bdms.assert_called_once_with(self.context, use_subordinate=True)
         mock_get_all(self.context, host_volume_bdms)
         mock_exists.assert_called_once_with(mock.ANY)
 
@@ -7042,8 +7042,8 @@ class ComputeTestCase(BaseTestCase,
         mock_cleanup.assert_called_once_with(ctxt, inst2, bdms,
                                              detach=False)
         mock_get_uuid.assert_has_calls([
-            mock.call(ctxt, inst1.uuid, use_slave=True),
-            mock.call(ctxt, inst2.uuid, use_slave=True)])
+            mock.call(ctxt, inst1.uuid, use_subordinate=True),
+            mock.call(ctxt, inst2.uuid, use_subordinate=True)])
         mock_get_inst.assert_called_once_with(ctxt,
                                               {'deleted': True,
                                                'soft_deleted': False})
@@ -7215,13 +7215,13 @@ class ComputeTestCase(BaseTestCase,
                 'require_nw_info': 0, 'setup_network': 0}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -7387,7 +7387,7 @@ class ComputeTestCase(BaseTestCase,
 
         def fake_instance_get_all_by_filters(context, filters,
                                              expected_attrs=None,
-                                             use_slave=False):
+                                             use_subordinate=False):
             self.assertEqual(["system_metadata"], expected_attrs)
             return instances
 
@@ -7437,7 +7437,7 @@ class ComputeTestCase(BaseTestCase,
                        task_states.REBOOTING, task_states.REBOOT_STARTED,
                        task_states.REBOOT_PENDING]}
         get.assert_called_once_with(ctxt, filters,
-                                    expected_attrs=[], use_slave=True)
+                                    expected_attrs=[], use_subordinate=True)
 
     def test_poll_unconfirmed_resizes(self):
         instances = [
@@ -7489,7 +7489,7 @@ class ComputeTestCase(BaseTestCase,
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for non-existing instance
@@ -7501,7 +7501,7 @@ class ComputeTestCase(BaseTestCase,
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -8024,7 +8024,7 @@ class ComputeTestCase(BaseTestCase,
 
         mock_get_filter.assert_called_once_with(ctxt, mock.ANY,
                 expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-                use_slave=True)
+                use_subordinate=True)
         mock_delete_old.assert_has_calls([mock.call(instance1, 3600),
                                           mock.call(instance2, 3600)])
         mock_get_uuid.assert_has_calls([mock.call(ctxt, instance1.uuid),
@@ -8054,9 +8054,9 @@ class ComputeTestCase(BaseTestCase,
         mock_get.assert_has_calls([mock.call(mock.ANY), mock.call(mock.ANY),
                                    mock.call(mock.ANY)])
         mock_sync.assert_has_calls([
-            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_slave=True)])
+            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_subordinate=True)])
 
     @mock.patch.object(compute_manager.ComputeManager, '_get_power_state')
     @mock.patch.object(compute_manager.ComputeManager,
@@ -12330,7 +12330,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-            aggregate=self.aggr, slave_info=None)
+            aggregate=self.aggr, subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -12343,35 +12343,35 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
-            aggregate=self.aggr, host="host", slave_info=None)
+            aggregate=self.aggr, host="host", subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(cls, context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate.id, self.aggr.id)
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-            slave_info="SLAVE_INFO", aggregate=self.aggr)
+            subordinate_info="SLAVE_INFO", aggregate=self.aggr)
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(cls, context, aggregate, host,
                                          **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate.id, self.aggr.id)
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
-            aggregate=self.aggr, host="the_host", slave_info="SLAVE_INFO")
+            aggregate=self.aggr, host="the_host", subordinate_info="SLAVE_INFO")
 
 
 class DisabledInstanceTypesTestCase(BaseTestCase):

--- a/nova/tests/unit/compute/test_compute_api.py
+++ b/nova/tests/unit/compute/test_compute_api.py
@@ -6852,7 +6852,7 @@ class ComputeAPIUnitTestCase(_ComputeAPIUnitTestMixIn, test.NoDBTestCase):
             self.context, instance, uuids.host, allow_cross_cell_resize=False)
         self.assertIs(node, mock_cn_get.return_value)
         mock_cn_get.assert_called_once_with(
-            self.context, uuids.host, use_slave=True)
+            self.context, uuids.host, use_subordinate=True)
 
     @mock.patch('nova.objects.HostMapping.get_by_host',
                 side_effect=exception.HostMappingNotFound(name=uuids.host))
@@ -6889,7 +6889,7 @@ class ComputeAPIUnitTestCase(_ComputeAPIUnitTestMixIn, test.NoDBTestCase):
         # cell-targeted context
         mock_cn_get.assert_called_once_with(
             mock_target_cell.return_value.__enter__.return_value,
-            uuids.host, use_slave=True)
+            uuids.host, use_subordinate=True)
 
     def _test_get_migrations_sorted_filter_duplicates(self, migrations,
                                                       expected):

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -336,7 +336,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
         get_db_nodes.return_value = db_nodes
         get_avail_nodes.return_value = avail_nodes
         self.compute.update_available_resource(self.context, startup=True)
-        get_db_nodes.assert_called_once_with(self.context, use_slave=True,
+        get_db_nodes.assert_called_once_with(self.context, use_subordinate=True,
                                              startup=True)
         self.assertEqual(len(avail_nodes_l), update_mock.call_count)
         update_mock.assert_has_calls(
@@ -400,7 +400,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
         self.assertEqual([], self.compute._get_compute_nodes_in_db(
             self.context, startup=True))
         get_all_by_host.assert_called_once_with(
-            self.context, self.compute.host, use_slave=False)
+            self.context, self.compute.host, use_subordinate=False)
         self.assertTrue(mock_log.warning.called)
         self.assertFalse(mock_log.error.called)
 
@@ -2010,7 +2010,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
                          [x['uuid'] for x in result])
         expected_filters = {'uuid': driver_uuids}
         mock_instance_list.assert_called_with(self.context, expected_filters,
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch('nova.objects.InstanceList.get_by_filters')
     def test_get_instances_on_driver_empty(self, mock_instance_list):
@@ -2065,7 +2065,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
                          [x['uuid'] for x in result])
         expected_filters = {'host': self.compute.host}
         mock_instance_list.assert_called_with(self.context, expected_filters,
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch.object(compute_utils, 'notify_usage_exists')
     @mock.patch.object(objects.TaskLog, 'end_task')
@@ -2105,7 +2105,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
             self.compute._sync_power_states(mock.sentinel.context)
             mock_get.assert_called_with(mock.sentinel.context,
                                         self.compute.host, expected_attrs=[],
-                                        use_slave=True)
+                                        use_subordinate=True)
             mock_spawn.assert_called_once_with(mock.ANY, instance)
 
     @mock.patch('nova.objects.InstanceList.get_by_host', new=mock.Mock())
@@ -2139,7 +2139,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
                                            vm_states.ACTIVE)
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.RUNNING)
-        mock_refresh.assert_called_once_with(use_slave=False)
+        mock_refresh.assert_called_once_with(use_subordinate=False)
 
     @mock.patch.object(fake_driver.FakeDriver, 'get_info')
     @mock.patch.object(objects.Instance, 'refresh')
@@ -2154,7 +2154,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.SHUTDOWN)
         self.assertEqual(instance.power_state, power_state.SHUTDOWN)
-        mock_refresh.assert_called_once_with(use_slave=False)
+        mock_refresh.assert_called_once_with(use_subordinate=False)
         self.assertTrue(mock_save.called)
         mock_get_info.assert_called_once_with(instance, use_cache=False)
 
@@ -2189,7 +2189,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
                                                power_state.CRASHED)):
                         mock_get_info.assert_called_once_with(instance,
                                                               use_cache=False)
-            mock_refresh.assert_called_once_with(use_slave=False)
+            mock_refresh.assert_called_once_with(use_subordinate=False)
             self.assertTrue(mock_save.called)
 
     def test_sync_instance_power_state_to_stop(self):
@@ -2246,7 +2246,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
             mock_sync_power_state.assert_called_once_with(self.context,
                                                           db_instance,
                                                           power_state.NOSTATE,
-                                                          use_slave=True)
+                                                          use_subordinate=True)
 
     def test_cleanup_running_deleted_instances_virt_driver_not_ready(self):
         """Tests the scenario that the driver raises VirtDriverNotReady
@@ -2279,13 +2279,13 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
             def save(self):
                 pass
 
-        def _fake_get(ctx, filter, expected_attrs, use_slave):
+        def _fake_get(ctx, filter, expected_attrs, use_subordinate):
             mock_get.assert_called_once_with(
                 {'read_deleted': 'yes'},
                 {'deleted': True, 'soft_deleted': False, 'host': 'fake-mini',
                  'cleaned': False},
                 expected_attrs=['system_metadata'],
-                use_slave=True)
+                use_subordinate=True)
             return [a, b, c]
 
         a = FakeInstance(uuids.instanceA, 'apple', {'clean_attempts': '100'})
@@ -5377,7 +5377,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
             self.compute._poll_bandwidth_usage(self.context)
             get_by_uuid_mac.assert_called_once_with(self.context,
                     uuids.instance, 'fake-mac',
-                    start_period=0, use_slave=True)
+                    start_period=0, use_subordinate=True)
             # NOTE(sdague): bw_usage_update happens at some time in
             # the future, so what last_refreshed is irrelevant.
             bw_usage_update.assert_called_once_with(self.context,
@@ -5482,7 +5482,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
         self.compute._sync_scheduler_instance_info(self.context)
         mock_get_by_host.assert_called_once_with(
                 fake_elevated, self.compute.host, expected_attrs=[],
-                use_slave=True)
+                use_subordinate=True)
         mock_sync.assert_called_once_with(fake_elevated, self.compute.host,
                                           exp_uuids)
 

--- a/nova/tests/unit/compute/test_compute_xen.py
+++ b/nova/tests/unit/compute/test_compute_xen.py
@@ -60,10 +60,10 @@ class ComputeXenTestCase(stubs.XenAPITestBaseNoDB):
             self.compute._sync_power_states(ctxt)
 
             mock_instance_list_get_by_host.assert_called_once_with(
-               ctxt, self.compute.host, expected_attrs=[], use_slave=True)
+               ctxt, self.compute.host, expected_attrs=[], use_subordinate=True)
             mock_compute_get_num_instances.assert_called_once_with()
             mock_compute_sync_powerstate.assert_called_once_with(
-               ctxt, instance, power_state.NOSTATE, use_slave=True)
+               ctxt, instance, power_state.NOSTATE, use_subordinate=True)
             mock_vm_utils_lookup.assert_called_once_with(
                self.compute.driver._session, instance['name'],
                False)

--- a/nova/tests/unit/compute/test_rpcapi.py
+++ b/nova/tests/unit/compute/test_rpcapi.py
@@ -195,7 +195,7 @@ class ComputeRpcAPITestCase(test.NoDBTestCase):
     def test_add_aggregate_host(self):
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_add_fixed_ip_to_instance(self):
         self._test_compute_api('add_fixed_ip_to_instance', 'cast',
@@ -718,7 +718,7 @@ class ComputeRpcAPITestCase(test.NoDBTestCase):
     def test_remove_aggregate_host(self):
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_remove_fixed_ip_from_instance(self):
         self._test_compute_api('remove_fixed_ip_from_instance', 'cast',

--- a/nova/tests/unit/conductor/test_conductor.py
+++ b/nova/tests/unit/conductor/test_conductor.py
@@ -3449,7 +3449,7 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
         get_source_node.assert_called_once_with(
             self.ctxt, instance.host, instance.node)
         get_dest_node.assert_called_once_with(
-            self.ctxt, 'dest-host', use_slave=True)
+            self.ctxt, 'dest-host', use_subordinate=True)
         notify.assert_called_once_with(
             self.ctxt, instance.uuid, 'rebuild_server',
             {'vm_state': instance.vm_state, 'task_state': None}, ex, reqspec)
@@ -3481,7 +3481,7 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
         get_source_node.assert_called_once_with(
             self.ctxt, instance.host, instance.node)
         get_dest_node.assert_called_once_with(
-            self.ctxt, 'dest-host', use_slave=True)
+            self.ctxt, 'dest-host', use_subordinate=True)
         claim.assert_called_once_with(
             self.ctxt, self.conductor.report_client, instance,
             get_source_node.return_value, get_dest_node.return_value)

--- a/nova/tests/unit/db/test_db_api.py
+++ b/nova/tests/unit/db/test_db_api.py
@@ -244,7 +244,7 @@ class DecoratorTestCase(test.TestCase):
     def test_select_db_reader_mode_select_sync(self, mock_clone, mock_using):
 
         @db.select_db_reader_mode
-        def func(self, context, value, use_slave=False):
+        def func(self, context, value, use_subordinate=False):
             pass
 
         mock_clone.return_value = enginefacade._TransactionContextManager(
@@ -261,21 +261,21 @@ class DecoratorTestCase(test.TestCase):
     def test_select_db_reader_mode_select_async(self, mock_clone, mock_using):
 
         @db.select_db_reader_mode
-        def func(self, context, value, use_slave=False):
+        def func(self, context, value, use_subordinate=False):
             pass
 
         mock_clone.return_value = enginefacade._TransactionContextManager(
             mode=enginefacade._ASYNC_READER)
         ctxt = context.get_admin_context()
         value = 'some_value'
-        func(self, ctxt, value, use_slave=True)
+        func(self, ctxt, value, use_subordinate=True)
 
         mock_clone.assert_called_once_with(mode=enginefacade._ASYNC_READER)
         mock_using.assert_called_once_with(ctxt)
 
     @mock.patch.object(enginefacade._TransactionContextManager, 'using')
     @mock.patch.object(enginefacade._TransactionContextManager, '_clone')
-    def test_select_db_reader_mode_no_use_slave_select_sync(self, mock_clone,
+    def test_select_db_reader_mode_no_use_subordinate_select_sync(self, mock_clone,
                                                             mock_using):
 
         @db.select_db_reader_mode
@@ -741,8 +741,8 @@ class SqlAlchemyDbApiNoDbTestCase(test.NoDBTestCase):
         mock_ctxt_mgr.writer.get_engine.assert_called_once_with()
 
     @mock.patch.object(sqlalchemy_api, 'main_context_manager')
-    def test_get_engine_use_slave(self, mock_ctxt_mgr):
-        sqlalchemy_api.get_engine(use_slave=True)
+    def test_get_engine_use_subordinate(self, mock_ctxt_mgr):
+        sqlalchemy_api.get_engine(use_subordinate=True)
         mock_ctxt_mgr.reader.get_engine.assert_called_once_with()
 
     def test_get_db_conf_with_connection(self):

--- a/nova/tests/unit/network/test_api.py
+++ b/nova/tests/unit/network/test_api.py
@@ -135,7 +135,7 @@ class ApiTestCase(test.TestCase):
 
         def fake_instance_get_by_uuid(context, instance_uuid,
                                       columns_to_join=None,
-                                      use_slave=None):
+                                      use_subordinate=None):
             if instance_uuid == orig_instance_uuid:
                 self.assertIn('extra.flavor', columns_to_join)
             return fake_instance.fake_db_instance(uuid=instance_uuid)

--- a/nova/tests/unit/network/test_linux_net.py
+++ b/nova/tests/unit/network/test_linux_net.py
@@ -357,7 +357,7 @@ class LinuxNetworkTestCase(test.NoDBTestCase):
         self.context = context.RequestContext('testuser', 'testproject',
                                               is_admin=True)
 
-        def get_vifs(_context, instance_uuid, use_slave):
+        def get_vifs(_context, instance_uuid, use_subordinate):
             return [vif for vif in vifs if vif['instance_uuid'] ==
                         instance_uuid]
 

--- a/nova/tests/unit/objects/test_instance.py
+++ b/nova/tests/unit/objects/test_instance.py
@@ -438,7 +438,7 @@ class _TestInstanceObject(object):
 
         inst.refresh()
         mock_get.assert_called_once_with(self.context, uuid=inst.uuid,
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
     @mock.patch.object(notifications, 'send_update')
     @mock.patch.object(db, 'instance_info_cache_update')
@@ -526,7 +526,7 @@ class _TestInstanceObject(object):
         mock_update_and_get.return_value = (old_ref, new_ref)
 
         inst = objects.Instance.get_by_uuid(self.context, old_ref['uuid'],
-                                            use_slave=False)
+                                            use_subordinate=False)
         self.assertEqual('hello', inst.display_name)
         inst.display_name = 'goodbye'
         inst.save()
@@ -1636,7 +1636,7 @@ class _TestInstanceListObject(object):
 
         inst_list = objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1653,7 +1653,7 @@ class _TestInstanceListObject(object):
 
         inst_list = objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, expected_attrs=['metadata'],
-            use_slave=False, sort_keys=['uuid'], sort_dirs=['asc'])
+            use_subordinate=False, sort_keys=['uuid'], sort_dirs=['asc'])
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1674,7 +1674,7 @@ class _TestInstanceListObject(object):
         # Single sort key/direction is set, call non-sorted DB function
         objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, sort_key='key', sort_dir='dir',
-            limit=100, marker='uuid', use_slave=True)
+            limit=100, marker='uuid', use_subordinate=True)
         mock_get_by_filters.assert_called_once_with(
             self.context, {'foo': 'bar'}, 'key', 'dir', limit=100,
             marker='uuid', columns_to_join=None)
@@ -1689,7 +1689,7 @@ class _TestInstanceListObject(object):
         # Multiple sort keys/directions are set, call sorted DB function
         objects.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, limit=100, marker='uuid',
-            use_slave=True, sort_keys=['key1', 'key2'],
+            use_subordinate=True, sort_keys=['key1', 'key2'],
             sort_dirs=['dir1', 'dir2'])
         mock_get_by_filters_sort.assert_called_once_with(
             self.context, {'foo': 'bar'}, limit=100,
@@ -1707,7 +1707,7 @@ class _TestInstanceListObject(object):
 
         inst_list = objects.InstanceList.get_by_filters(
             self.context, {'deleted': True, 'cleaned': False}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         self.assertEqual(1, len(inst_list))
         self.assertIsInstance(inst_list.objects[0], instance.Instance)
@@ -1837,7 +1837,7 @@ class _TestInstanceListObject(object):
 
         instances = objects.InstanceList.get_by_host(self.context, 'host',
                                                      expected_attrs=['fault'],
-                                                     use_slave=False)
+                                                     use_subordinate=False)
         self.assertEqual(2, len(instances))
         self.assertEqual(fake_faults['fake-uuid'][0],
                          dict(instances[0].fault))

--- a/nova/tests/unit/objects/test_migration.py
+++ b/nova/tests/unit/objects/test_migration.py
@@ -224,7 +224,7 @@ class _TestMigrationObject(object):
         mock_get.return_value = db_migrations
         migrations = (
             migration.MigrationList.get_unconfirmed_by_dest_compute(
-                ctxt, 'window', 'foo', use_slave=False))
+                ctxt, 'window', 'foo', use_subordinate=False))
         self.assertEqual(2, len(migrations))
         for index, db_migration in enumerate(db_migrations):
             self.compare_obj(migrations[index], db_migration)

--- a/nova/tests/unit/test_fixtures.py
+++ b/nova/tests/unit/test_fixtures.py
@@ -412,7 +412,7 @@ class TestAllServicesCurrentFixture(testtools.TestCase):
         self.assertEqual(123, service_obj.Service.get_minimum_version(
             None, 'nova-compute'))
         mock_db.assert_called_once_with(None, ['nova-compute'],
-                                        use_slave=False)
+                                        use_subordinate=False)
         mock_db.reset_mock()
         compute_rpcapi.LAST_VERSION = 123
         self.useFixture(fixtures.AllServicesCurrent())

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -16169,7 +16169,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
             self.assertEqual(2, mock_info.call_count)
 
         filters = {'uuid': instance_uuids}
-        mock_get.assert_called_once_with(mock.ANY, filters, use_slave=True)
+        mock_get.assert_called_once_with(mock.ANY, filters, use_subordinate=True)
         mock_bdms.assert_called_with(mock.ANY, instance_uuids)
 
     @mock.patch.object(host.Host, "list_instance_domains")
@@ -16279,7 +16279,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         mock_list.assert_called_once_with(only_running=False)
         self.assertEqual(5, get_disk_info.call_count)
         filters = {'uuid': instance_uuids}
-        mock_get.assert_called_once_with(mock.ANY, filters, use_slave=True)
+        mock_get.assert_called_once_with(mock.ANY, filters, use_subordinate=True)
         mock_bdms.assert_called_with(mock.ANY, instance_uuids)
 
     @mock.patch.object(host.Host, "list_instance_domains")

--- a/nova/tests/unit/virt/libvirt/test_imagecache.py
+++ b/nova/tests/unit/virt/libvirt/test_imagecache.py
@@ -606,7 +606,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
                 'soft_deleted': True,
             }
             mock_instance_list.assert_called_once_with(
-                ctxt, filters, expected_attrs=[], use_slave=True)
+                ctxt, filters, expected_attrs=[], use_subordinate=True)
 
     def test_store_swap_image(self):
         image_cache_manager = imagecache.ImageCacheManager()

--- a/nova/tests/unit/virt/xenapi/test_xenapi.py
+++ b/nova/tests/unit/virt/xenapi/test_xenapi.py
@@ -3127,7 +3127,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.aggr = objects.Aggregate(context=self.context, id=1,
                                       **values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               'availability_zone': 'fake_zone',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
@@ -3137,15 +3137,15 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
     @mock.patch('nova.virt.xenapi.pool.ResourcePool.add_to_aggregate')
     def test_pool_add_to_aggregate_called_by_driver(
             self, mock_add_to_aggregate):
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
         mock_add_to_aggregate.side_effect = pool_add_to_aggregate
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertTrue(mock_add_to_aggregate.called)
 
@@ -3153,14 +3153,14 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
     def test_pool_remove_from_aggregate_called_by_driver(
             self, mock_remove_from_aggregate):
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
         mock_remove_from_aggregate.side_effect = pool_remove_from_aggregate
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertTrue(mock_remove_from_aggregate.called)
 
@@ -3174,9 +3174,9 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result.metadata))
 
-    @mock.patch('nova.virt.xenapi.pool.ResourcePool._join_slave')
-    def test_join_slave(self, mock_join_slave):
-        # Ensure join_slave gets called when the request gets to master.
+    @mock.patch('nova.virt.xenapi.pool.ResourcePool._join_subordinate')
+    def test_join_subordinate(self, mock_join_subordinate):
+        # Ensure join_subordinate gets called when the request gets to main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
         self.conn._pool.add_to_aggregate(self.context, aggregate, "host2",
@@ -3185,7 +3185,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(mock_join_slave.called)
+        self.assertTrue(mock_join_subordinate.called)
 
     @mock.patch.object(xenapi_fake.SessionBase, 'pool_set_name_label')
     def test_add_to_aggregate_first_host(self, mock_pool_set_name_label):
@@ -3217,17 +3217,17 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    @mock.patch('nova.virt.xenapi.pool.ResourcePool._eject_slave')
-    def test_remove_slave(self, mock_eject_slave):
-        # Ensure eject slave gets called.
+    @mock.patch('nova.virt.xenapi.pool.ResourcePool._eject_subordinate')
+    def test_remove_subordinate(self, mock_eject_subordinate):
+        # Ensure eject subordinate gets called.
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(mock_eject_slave.called)
+        self.assertTrue(mock_eject_subordinate.called)
 
     @mock.patch('nova.virt.xenapi.pool.ResourcePool._clear_pool')
-    def test_remove_master_solo(self, mock_clear_pool):
+    def test_remove_main_solo(self, mock_clear_pool):
         # Ensure metadata are cleared after removal.
         aggregate = self._aggregate_setup(metadata=self.fake_metadata)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host")
@@ -3238,8 +3238,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result.metadata))
 
-    def test_remote_master_non_empty_pool(self):
-        # Ensure AggregateError is raised if removing the master.
+    def test_remote_main_non_empty_pool(self):
+        # Ensure AggregateError is raised if removing the main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -3357,7 +3357,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.compute.add_aggregate_host,
                           self.context, host="fake_host",
                           aggregate=self.aggr,
-                          slave_info=None)
+                          subordinate_info=None)
         self.assertEqual(self.aggr.metadata[pool_states.KEY],
                 pool_states.ERROR)
         self.assertEqual(self.aggr.hosts, ['fake_host'])
@@ -3368,16 +3368,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, host, aggregate_id, host_param,
-                              slave_info):
+                              subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, host, aggregate_id,
-            host_param, slave_info))
+            host_param, subordinate_info))
 
 
 class StubDependencies(object):
@@ -3392,10 +3392,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -3409,33 +3409,33 @@ class HypervisorPoolTestCase(test.NoDBTestCase):
         'id': 98,
         'hosts': [],
         'metadata': {
-            'master_compute': 'master',
+            'main_compute': 'main',
             pool_states.POOL_FLAG: '',
             pool_states.KEY: ''
             }
         }
     fake_aggregate = objects.Aggregate(**fake_aggregate)
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.add_to_aggregate("CONTEXT", self.fake_aggregate, "slave")
-
-        self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
-            "CONTEXT", "slave", self.fake_aggregate,
-            "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
-
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
-
-        slave.remove_from_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-             "CONTEXT", "slave", 98, "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.add_aggregate_host,
+            "CONTEXT", "subordinate", self.fake_aggregate,
+            "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
+
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
+
+        subordinate.remove_from_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
+
+        self.assertIn(
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+             "CONTEXT", "subordinate", 98, "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.NoDBTestCase):

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -9550,7 +9550,7 @@ class LibvirtDriver(driver.ComputeDriver):
         # in _update_available_resource method for calculating usages based
         # on instance utilization.
         local_instance_list = objects.InstanceList.get_by_filters(
-            ctx, filters, use_slave=True)
+            ctx, filters, use_subordinate=True)
         # Convert instance list to dictionary with instance uuid as key.
         local_instances = {inst.uuid: inst for inst in local_instance_list}
 

--- a/nova/virt/xenapi/fake.py
+++ b/nova/virt/xenapi/fake.py
@@ -124,7 +124,7 @@ def create_host(name_label, hostname='fake_name', address='fake_addr',
     # Create a pool if we don't have one already
     if len(_db_content['pool']) == 0:
         pool_ref = _create_pool('')
-        _db_content['pool'][pool_ref]['master'] = host_ref
+        _db_content['pool'][pool_ref]['main'] = host_ref
         _db_content['pool'][pool_ref]['default-SR'] = host_default_sr_ref
         _db_content['pool'][pool_ref]['suspend-image-SR'] = host_default_sr_ref
 
@@ -935,7 +935,7 @@ class SessionBase(object):
             return self._session
         elif name == 'xenapi':
             return _Dispatcher(self.xenapi_request, None)
-        elif name.startswith('login') or name.startswith('slave_local'):
+        elif name.startswith('login') or name.startswith('subordinate_local'):
             return lambda *params: self._login(name, params)
         elif name.startswith('Async'):
             return lambda *params: self._async(name, params)

--- a/nova/virt/xenapi/pool.py
+++ b/nova/virt/xenapi/pool.py
@@ -58,7 +58,7 @@ class ResourcePool(object):
                             'state during operation on %(host)s'),
                           {'aggregate_id': aggregate.id, 'host': host})
 
-    def add_to_aggregate(self, context, aggregate, host, slave_info=None):
+    def add_to_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Add a compute host to an aggregate."""
         if not pool_states.is_hv_pool(aggregate.metadata):
             return
@@ -80,38 +80,38 @@ class ResourcePool(object):
         if (aggregate.metadata[pool_states.KEY] == pool_states.CREATED):
             aggregate.update_metadata({pool_states.KEY: pool_states.CHANGING})
         if len(aggregate.hosts) == 1:
-            # this is the first host of the pool -> make it master
+            # this is the first host of the pool -> make it main
             self._init_pool(aggregate.id, aggregate.name)
-            # save metadata so that we can find the master again
-            metadata = {'master_compute': host,
+            # save metadata so that we can find the main again
+            metadata = {'main_compute': host,
                         host: self._host_uuid,
                         pool_states.KEY: pool_states.ACTIVE}
             aggregate.update_metadata(metadata)
         else:
             # the pool is already up and running, we need to figure out
             # whether we can serve the request from this host or not.
-            master_compute = aggregate.metadata['master_compute']
-            if master_compute == CONF.host and master_compute != host:
-                # this is the master ->  do a pool-join
-                # To this aim, nova compute on the slave has to go down.
+            main_compute = aggregate.metadata['main_compute']
+            if main_compute == CONF.host and main_compute != host:
+                # this is the main ->  do a pool-join
+                # To this aim, nova compute on the subordinate has to go down.
                 # NOTE: it is assumed that ONLY nova compute is running now
-                self._join_slave(aggregate.id, host,
-                                 slave_info.get('compute_uuid'),
-                                 slave_info.get('url'), slave_info.get('user'),
-                                 slave_info.get('passwd'))
-                metadata = {host: slave_info.get('xenhost_uuid'), }
+                self._join_subordinate(aggregate.id, host,
+                                 subordinate_info.get('compute_uuid'),
+                                 subordinate_info.get('url'), subordinate_info.get('user'),
+                                 subordinate_info.get('passwd'))
+                metadata = {host: subordinate_info.get('xenhost_uuid'), }
                 aggregate.update_metadata(metadata)
-            elif master_compute and master_compute != host:
-                # send rpc cast to master, asking to add the following
+            elif main_compute and main_compute != host:
+                # send rpc cast to main, asking to add the following
                 # host with specified credentials.
-                slave_info = self._create_slave_info()
+                subordinate_info = self._create_subordinate_info()
 
                 self.compute_rpcapi.add_aggregate_host(
-                    context, host, aggregate, master_compute, slave_info)
+                    context, host, aggregate, main_compute, subordinate_info)
 
-    def remove_from_aggregate(self, context, aggregate, host, slave_info=None):
+    def remove_from_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Remove a compute host from an aggregate."""
-        slave_info = slave_info or dict()
+        subordinate_info = subordinate_info or dict()
         if not pool_states.is_hv_pool(aggregate.metadata):
             return
 
@@ -123,19 +123,19 @@ class ResourcePool(object):
                     aggregate_id=aggregate.id,
                     reason=invalid[aggregate.metadata[pool_states.KEY]])
 
-        master_compute = aggregate.metadata['master_compute']
-        if master_compute == CONF.host and master_compute != host:
-            # this is the master -> instruct it to eject a host from the pool
+        main_compute = aggregate.metadata['main_compute']
+        if main_compute == CONF.host and main_compute != host:
+            # this is the main -> instruct it to eject a host from the pool
             host_uuid = aggregate.metadata[host]
-            self._eject_slave(aggregate.id,
-                              slave_info.get('compute_uuid'), host_uuid)
+            self._eject_subordinate(aggregate.id,
+                              subordinate_info.get('compute_uuid'), host_uuid)
             aggregate.update_metadata({host: None})
-        elif master_compute == host:
-            # Remove master from its own pool -> destroy pool only if the
-            # master is on its own, otherwise raise fault. Destroying a
-            # pool made only by master is fictional
+        elif main_compute == host:
+            # Remove main from its own pool -> destroy pool only if the
+            # main is on its own, otherwise raise fault. Destroying a
+            # pool made only by main is fictional
             if len(aggregate.hosts) > 1:
-                # NOTE: this could be avoided by doing a master
+                # NOTE: this could be avoided by doing a main
                 # re-election, but this is simpler for now.
                 raise exception.InvalidAggregateActionDelete(
                                     aggregate_id=aggregate.id,
@@ -143,32 +143,32 @@ class ResourcePool(object):
                                              'from the pool; pool not empty')
                                              % host)
             self._clear_pool(aggregate.id)
-            aggregate.update_metadata({'master_compute': None, host: None})
-        elif master_compute and master_compute != host:
-            # A master exists -> forward pool-eject request to master
-            slave_info = self._create_slave_info()
+            aggregate.update_metadata({'main_compute': None, host: None})
+        elif main_compute and main_compute != host:
+            # A main exists -> forward pool-eject request to main
+            subordinate_info = self._create_subordinate_info()
 
             self.compute_rpcapi.remove_aggregate_host(
-                context, host, aggregate.id, master_compute, slave_info)
+                context, host, aggregate.id, main_compute, subordinate_info)
         else:
             # this shouldn't have happened
             raise exception.AggregateError(aggregate_id=aggregate.id,
                                            action='remove_from_aggregate',
                                            reason=_('Unable to eject %s '
-                                           'from the pool; No master found')
+                                           'from the pool; No main found')
                                            % host)
 
-    def _join_slave(self, aggregate_id, host, compute_uuid, url, user, passwd):
-        """Joins a slave into a XenServer resource pool."""
+    def _join_subordinate(self, aggregate_id, host, compute_uuid, url, user, passwd):
+        """Joins a subordinate into a XenServer resource pool."""
         try:
             args = {'compute_uuid': compute_uuid,
                     'url': url,
                     'user': user,
                     'password': passwd,
                     'force': jsonutils.dumps(CONF.xenserver.use_join_force),
-                    'master_addr': self._host_addr,
-                    'master_user': CONF.xenserver.connection_username,
-                    'master_pass': CONF.xenserver.connection_password, }
+                    'main_addr': self._host_addr,
+                    'main_user': CONF.xenserver.connection_username,
+                    'main_pass': CONF.xenserver.connection_password, }
             self._session.call_plugin('xenhost.py', 'host_join', args)
         except self._session.XenAPI.Failure as e:
             LOG.error("Pool-Join failed: %s", e)
@@ -177,8 +177,8 @@ class ResourcePool(object):
                                            reason=_('Unable to join %s '
                                                   'in the pool') % host)
 
-    def _eject_slave(self, aggregate_id, compute_uuid, host_uuid):
-        """Eject a slave from a XenServer resource pool."""
+    def _eject_subordinate(self, aggregate_id, compute_uuid, host_uuid):
+        """Eject a subordinate from a XenServer resource pool."""
         try:
             # shutdown nova-compute; if there are other VMs running, e.g.
             # guest instances, the eject will fail. That's a precaution
@@ -217,7 +217,7 @@ class ResourcePool(object):
                                            action='remove_from_aggregate',
                                            reason=six.text_type(e.details))
 
-    def _create_slave_info(self):
+    def _create_subordinate_info(self):
         """XenServer specific info needed to join the hypervisor pool."""
         # replace the address from the xenapi connection url
         # because this might be 169.254.0.1, i.e. xenapi

--- a/nova/virt/xenapi/pool_states.py
+++ b/nova/virt/xenapi/pool_states.py
@@ -25,7 +25,7 @@ cases.
 A 'created' pool becomes 'changing' during the first request of
 adding a host. During a 'changing' status no other requests will be accepted;
 this is to allow the hypervisor layer to instantiate the underlying pool
-without any potential race condition that may incur in master/slave-based
+without any potential race condition that may incur in main/subordinate-based
 configurations. The pool goes into the 'active' state when the underlying
 pool has been correctly instantiated.
 All other operations (e.g. add/remove hosts) that succeed will keep the

--- a/releasenotes/source/conf.py
+++ b/releasenotes/source/conf.py
@@ -37,8 +37,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 copyright = u'2015, Nova developers'

--- a/tools/db/schema_diff.py
+++ b/tools/db/schema_diff.py
@@ -33,12 +33,12 @@ Run like:
     MYSQL:
 
     ./tools/db/schema_diff.py mysql+pymysql://root@localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 
     POSTGRESQL:
 
     ./tools/db/schema_diff.py postgresql://localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 
 """
 
@@ -229,12 +229,12 @@ def parse_options():
     try:
         orig_branch, orig_version = sys.argv[2].split(':')
     except IndexError:
-        usage('original branch and version required (e.g. master:82)')
+        usage('original branch and version required (e.g. main:82)')
 
     try:
         new_branch, new_version = sys.argv[3].split(':')
     except IndexError:
-        usage('new branch and version required (e.g. master:82)')
+        usage('new branch and version required (e.g. main:82)')
 
     return db_url, orig_branch, orig_version, new_branch, new_version
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.